### PR TITLE
Add support for concat(), contains() XPath functions.

### DIFF
--- a/src/mochiweb_xpath_functions.erl
+++ b/src/mochiweb_xpath_functions.erl
@@ -23,7 +23,9 @@ default_functions() ->
         {'starts-with', fun 'starts-with'/2,[string,string]},
         {'substring', fun substring/2,[string,number,number]},
         {'sum', fun sum/2,[node_set]},
-        {'string-length', fun 'string-length'/2,[string]}
+        {'string-length', fun 'string-length'/2,[string]},
+        {'contains', fun contains/2,[string,string]},
+        {'concat', fun concat/2,[string,string,string]}
     ].
 
 
@@ -85,3 +87,19 @@ sum(_Ctx,[Values]) ->
 %%            in the string, that isn't the same 
 'string-length'(_Ctx,[String]) ->
     size(String).
+
+%% @doc Function: boolean contains(string, string)
+%%      The contains function returns true if the second string is contained
+%%      within the first.
+%%      TODO: not Unicode safe.
+contains(_Ctx,[Haystack,Needle]) ->
+    string:str(binary_to_list(Haystack), binary_to_list(Needle)) /= 0.
+
+%% @doc Function: string concat(string...)
+%%      Returns the concatenation of all given strings.
+concat(_Ctx,Strs) ->
+    lists:foldr(
+        fun(A,B) -> <<A/binary, B/binary>> end,
+        <<>>,
+        Strs
+    ).

--- a/test/html-docs/test1.html
+++ b/test/html-docs/test1.html
@@ -37,6 +37,7 @@ rthrthrthrthrttrthtrhrt thrhrthrthrt
 <img src="someimg" alt="sssssss"/>
 <p>ssdsdsdsdssds</p>
 </div>
+<div class="ab bc cd">oh no</div>
 <ul>
 <li>sss
 <li>ssd

--- a/test/mochiweb_xpath_tests.erl
+++ b/test/mochiweb_xpath_tests.erl
@@ -22,6 +22,8 @@ test_definitions() ->
                {"/html/head/title/text()",[<<"Title">>]},
                {"/html/head/meta[2]/@content",[<<"text/html; charset=utf-8">>]},
                {"/html/body/div[@id='first']/@class",[<<"normal">>]},
+               % A bug in xmerl_xpath_scan means concat(' ', @class, ' ') fails to tokenise.
+               {"/html/body/div[contains(concat(' ', (@class), ' '), ' cd ')]/text()", [<<"oh no">>]},
                {"/html/body/form/input[@name='id3']/@value",[<<"Val3">>]},
                {"/html/body/*/input[@name='id3']/@value",[<<"Val3">>]},
                {"/html/head/title/text() = 'Title'",true},


### PR DESCRIPTION
This commit adds support for the `concat()` and `contains()` XPath functions, as well as a test demonstrating their most common use case (`//div[contains(concat(' ', @class, ' '), ' blah ')]`).

Note that the `xmerl_xpath_scan` has a bug; it fails to tokenise `(' ', @class, ' ')` (or `(' ', attribute::class, ' ')`), so the test works around it by wrapping `@class` in parens. I'll probably try to fix that next, but that's a longer process.

In the mean time, these functions can be enjoyed by all.
