### PR TITLE
function last() must return a number equal to the context size of the current node

### DIFF
--- a/src/mochiweb_xpath_functions.erl
+++ b/src/mochiweb_xpath_functions.erl
@@ -47,10 +47,10 @@ lookup_function('string') ->
 lookup_function(_) ->
     false.
 
-%% @doc Function: boolean last() 
-%%      The position function returns the position of the current node
-last({ctx, _, _, _, Position, Size} = _Ctx, []) ->
-    Position =:= Size.
+%% @doc Function: int last() 
+%%      The last function returns the context size of the current node
+last({ctx, _, _, _, _, Size} = _Ctx, []) ->
+    Size.
 
 %% @doc Function: number position() 
 %%      The position function returns the position of the current node

--- a/test/mochiweb_xpath_tests.erl
+++ b/test/mochiweb_xpath_tests.erl
@@ -36,7 +36,7 @@ test_definitions() ->
                {"/html/body/*/input[position() = 3]/@value",[<<"Val3">>]},
                {"/html/body/*/input[position() > 3]/@value",[<<"Val4">>,<<"Val5">>,<<"Val6">>]},
                {"/html/body/*/input[@type='hidden']/@value",[<<"Val1">>,<<"Val2">>,<<"Val3">>,<<"Val4">>,<<"Val5">>,<<"Val6">>]},
-               {"/html/body/*/input[@type='hidden'][last()]/@value",[<<"Val6">>]},
+               {"/html/body/*/input[@type='hidden'][position() = last()]/@value",[<<"Val6">>]},
                {"/html/body/*/input[@type='hidden'][position()>1]/@value",[<<"Val2">>,<<"Val3">>,<<"Val4">>,<<"Val5">>,<<"Val6">>]},
 
                {"string(//div[@class='normal']/cite)",[<<"one-two-three-(nested-[deeply-four-done]-done)-five">>, <<"other stuff">>]},


### PR DESCRIPTION
As mentioned in the [XPath 1.0 Recommendation](http://www.w3.org/TR/xpath/#function-last) the function last() should return a number.
With my upcoming pull request it will be possible again to index with last() concerning to the support for abbreviated syntax for accessing indexed.