### PR TITLE
Support abbreviated syntax to access indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ Xpath coverage
 * sum
 * string-length
 * not
+ 
+
+### Implemented abbreviated syntax
+
+* indexed access (e.g. `div[last() - 1]`)
+
 
 ### TODO axes
 

--- a/test/mochiweb_xpath_tests.erl
+++ b/test/mochiweb_xpath_tests.erl
@@ -39,6 +39,10 @@ test_definitions() ->
                {"/html/body/*/input[@type='hidden'][last()]/@value",[<<"Val6">>]},
                {"/html/body/*/input[@type='hidden'][position()>1]/@value",[<<"Val2">>,<<"Val3">>,<<"Val4">>,<<"Val5">>,<<"Val6">>]},
 
+               % testing the abbreviated syntax to access indexed
+               {"count(/html/body/form[position()]/*)", 8},
+               {"/html/body/*/input[3 + 0]/@value",[<<"Val3">>]},
+
                {"string(//div[@class='normal']/cite)",[<<"one-two-three-(nested-[deeply-four-done]-done)-five">>, <<"other stuff">>]},
                {"name(/html/body/*/input[@type='hidden'][@name=\"id1\"]/..)",<<"form">>},
                {"name(/html/body/*/input[@type='hidden'][@name=\"id1\"]/../..)",<<"body">>},


### PR DESCRIPTION
This merge provides support for indexed access like mentioned in the [XPath 1.0 Recommendation](http://www.w3.org/TR/xpath/#path-abbrev).

For example:
```
    div[last() - 1]
```    